### PR TITLE
Remove hardcoded value in transaction ID

### DIFF
--- a/src/Message/Checkout/AuthorizeRequest.php
+++ b/src/Message/Checkout/AuthorizeRequest.php
@@ -66,7 +66,7 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         $data = [
             'additionalData' => $additionalData,
             'amount' => $amount,
-            'reference' => 'GISPENOUTLETNL-'.(string)$this->getTransactionId(),
+            'reference' => $this->getTransactionId(),
             'merchantAccount' => $this->getMerchantAccount(),
             'shopperInteraction' => 'Ecommerce'
         ];


### PR DESCRIPTION
This value should be set using the transaction ID and should not be hardcoded in the AuthorizeRequest.