### PR TITLE
Allow additional params through

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,9 +797,9 @@ The plugin supports configuration of the live environment URLs through environme
 - `liveInstance`: Custom instance name for the live environment URL (e.g., 'custom')
 
 Example URL formats:
-- Test environment: `https://checkout-test.adyen.com/v67/payments`
-- Live environment (default): `https://checkout-live.adyenpayments.com/checkout/v67/payments`
-- Live environment (custom): `https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/v67/payments`
+- Test environment: `https://checkout-test.adyen.com/v69/payments`
+- Live environment (default): `https://checkout-live.adyenpayments.com/checkout/v69/payments`
+- Live environment (custom): `https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/v69/payments`
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Table of Contents
          * [Notification Server Request (from gateway)](#notification-server-request-from-gateway)
          * [Notification Response (to gateway)](#notification-response-to-gateway)
       * [Support](#support)
+      * [Environment Configuration](#environment-configuration)
+         * [Live Environment URL Configuration](#live-environment-url-configuration)
+         * [Example Configuration](#example-configuration)
 
 ## Installation
 
@@ -783,3 +786,32 @@ so it can be easily found.
 If you believe you have found a bug, please report it using the
 [GitHub issue tracker](https://github.com/academe/omnipay-adyen/issues),
 or better yet, fork the library and submit a pull request.
+
+## Environment Configuration
+
+The plugin supports configuration of the live environment URLs through environment variables:
+
+### Live Environment URL Configuration
+
+- `livePrefix`: Custom prefix for the live environment URL (e.g., 'xxx-xxx')
+- `liveInstance`: Custom instance name for the live environment URL (e.g., 'custom')
+
+Example URL formats:
+- Test environment: `https://checkout-test.adyen.com/v67/payments`
+- Live environment (default): `https://checkout-live.adyenpayments.com/checkout/v67/payments`
+- Live environment (custom): `https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/v67/payments`
+
+### Example Configuration
+
+```php
+$gateway = Omnipay::create('Adyen');
+$gateway->initialize([
+    'merchantAccount' => 'YourMerchantAccount',
+    'merchantAccountId' => 'YourMerchantAccountId',
+    'apiKey' => 'YourApiKey',
+    'testMode' => false,
+    'currency' => 'USD',
+    'livePrefix' => 'xxx-xxx',
+    'liveInstance' => 'custom'
+]);
+```

--- a/composer.json
+++ b/composer.json
@@ -28,16 +28,25 @@
         }
     },
     "require": {
-        "omnipay/common": "~3.0"
+        "php": "^7.4|^8.0",
+        "omnipay/common": "^3.0",
+        "symfony/http-client": "^7.3",
+        "php-http/httplug": "^2.4",
+        "nyholm/psr7": "^1.8"
     },
     "require-dev": {
-        "omnipay/tests": "~3.0",
-        "squizlabs/php_codesniffer": "^3"
+        "squizlabs/php_codesniffer": "^3",
+        "phpunit/phpunit": "^9.0"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,25 +28,16 @@
         }
     },
     "require": {
-        "php": "^7.4|^8.0",
-        "omnipay/common": "^3.0",
-        "symfony/http-client": "^7.3",
-        "php-http/httplug": "^2.4",
-        "nyholm/psr7": "^1.8"
+        "omnipay/common": "~3.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^3",
-        "phpunit/phpunit": "^9.0"
+        "omnipay/tests": "~3.0",
+        "squizlabs/php_codesniffer": "^3"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "3.0.x-dev"
         }
     },
-    "prefer-stable": true,
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": true
-        }
-    }
+    "prefer-stable": true
 }

--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -23,13 +23,15 @@ abstract class AbstractGateway extends CommonAbstractGateway
             'skinCode' => null,
             'secret' => '',
             'apiKey' => '',
-            'currency' => 'EUR',
+            'currency' => 'USD',
             'publicKeyToken' => '',             // publicKeyToken aka Library Token.
             'username' => '',
             'password' => '',
             'testMode' => true,
-            'shopperLocale' => 'nl_NL',
-            'countryCode' => 'nl'
+            'shopperLocale' => 'en_US',
+            'countryCode' => 'us',
+            'livePrefix' => '',
+            'liveInstance' => 'live-us',
         ];
     }
 }

--- a/src/AbstractGateway.php
+++ b/src/AbstractGateway.php
@@ -4,6 +4,7 @@ namespace Omnipay\Adyen;
 
 use Omnipay\Common\AbstractGateway as CommonAbstractGateway;
 use Omnipay\Adyen\Traits\GatewayParameters;
+use Omnipay\Adyen\Traits\PreservedParameters;
 use Omnipay\Adyen\Message\FetchPaymentMethodsRequest;
 use Omnipay\Adyen\Message\AuthorizeRequest;
 use Omnipay\Adyen\Message\CompleteAuthorizeRequest;
@@ -12,6 +13,7 @@ use Omnipay\Adyen\Message\CseClientRequest;
 abstract class AbstractGateway extends CommonAbstractGateway
 {
     use GatewayParameters;
+    use PreservedParameters;
 
     /**
      *

--- a/src/CheckoutGateway.php
+++ b/src/CheckoutGateway.php
@@ -77,4 +77,9 @@ class CheckoutGateway extends ApiGateway
         return $this->createRequest(CreateModificationRequest::class, $parameters);
     }
 
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest(CreateModificationRequest::class, $parameters);
+    }
+
 }

--- a/src/CheckoutGateway.php
+++ b/src/CheckoutGateway.php
@@ -67,7 +67,12 @@ class CheckoutGateway extends ApiGateway
         return $this->createRequest(CreateSessionRequest::class, $parameters);
     }
 
-    public function modification(array $parameters = array())
+    public function capture(array $parameters = array())
+    {
+        return $this->createRequest(CreateModificationRequest::class, $parameters);
+    }
+
+    public function refund(array $parameters = array())
     {
         return $this->createRequest(CreateModificationRequest::class, $parameters);
     }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -14,7 +14,7 @@ use Omnipay\Adyen\Message\Checkout\CreateSessionRequest;
 use Omnipay\Adyen\Message\Checkout\PaymentMethodRequest;
 use Omnipay\Common\PaymentMethod;
 
-class CheckoutGateway extends ApiGateway
+class Gateway extends ApiGateway
 {
     public function getName()
     {

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -77,4 +77,9 @@ class Gateway extends ApiGateway
         return $this->createRequest(CreateModificationRequest::class, $parameters);
     }
 
+    public function void(array $parameters = array())
+    {
+        return $this->createRequest(CreateModificationRequest::class, $parameters);
+    }
+
 }

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -67,7 +67,12 @@ class Gateway extends ApiGateway
         return $this->createRequest(CreateSessionRequest::class, $parameters);
     }
 
-    public function modification(array $parameters = array())
+    public function capture(array $parameters = array())
+    {
+        return $this->createRequest(CreateModificationRequest::class, $parameters);
+    }
+
+    public function refund(array $parameters = array())
     {
         return $this->createRequest(CreateModificationRequest::class, $parameters);
     }

--- a/src/Message/AbstractCheckoutRequest.php
+++ b/src/Message/AbstractCheckoutRequest.php
@@ -37,7 +37,7 @@ abstract class AbstractCheckoutRequest extends AbstractApiRequest
 
         $keysToRemove = ['paymentPspReference', 'modificationAction'];
 
-        if ($parameters['modificationAction'] == 'reversals') {
+        if (isset($parameters['modificationAction']) && $parameters['modificationAction'] === 'reversals') {
             $keysToRemove[] = 'amount';
         }
 

--- a/src/Message/AbstractCheckoutRequest.php
+++ b/src/Message/AbstractCheckoutRequest.php
@@ -86,6 +86,9 @@ abstract class AbstractCheckoutRequest extends AbstractApiRequest
             $data['riskData']['clientData'] = $this->getRiskData()['clientData'];
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/AbstractCheckoutRequest.php
+++ b/src/Message/AbstractCheckoutRequest.php
@@ -48,6 +48,47 @@ abstract class AbstractCheckoutRequest extends AbstractApiRequest
         return [$endpoint, $parameters];
     }
 
+    /**
+     * Add common optional parameters to the data array.
+     * This method consolidates the duplicate parameter setting logic
+     * used by both AuthorizeRequest and CreateCardRequest.
+     *
+     * @param array $data The data array to add parameters to
+     * @return array The data array with optional parameters added
+     */
+    protected function addCommonOptionalParameters(array $data): array
+    {
+        if (!empty($this->getShopperReference())) {
+            $data['shopperReference'] = $this->getShopperReference();
+        }
+        if (!empty($this->getReturnUrl())) {
+            $data['returnUrl'] = $this->getReturnUrl();
+        }
+        if (!empty($this->getShopperName())) {
+            $data['shopperName'] = $this->getShopperName();
+        }
+        if (!empty($this->getShopperEmail())) {
+            $data['shopperEmail'] = $this->getShopperEmail();
+        }
+        if (!empty($this->getClientIp())) {
+            $data['shopperIP'] = $this->getClientIp();
+        }
+        if (!empty($this->getBillingAddress())) {
+            $data['billingAddress'] = $this->getBillingAddress();
+        }
+        if (!empty($this->getDeliveryAddress())) {
+            $data['deliveryAddress'] = $this->getDeliveryAddress();
+        }
+        if (!empty($this->getBrowserInfo())) {
+            $data['browserInfo'] = $this->getBrowserInfo();
+        }
+        if (!empty($this->getRiskData()) && !empty($this->getRiskData()['clientData'])) {
+            $data['riskData']['clientData'] = $this->getRiskData()['clientData'];
+        }
+
+        return $data;
+    }
+
     abstract public function createResponse($payload);
 
 }

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -18,9 +18,9 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
     const INSTANCE_TEST = 'test';
 
     const VERSION_DIRECTORY         = 'v2';
-    const VERSION_CHECKOUT          = 'v67';
+    const VERSION_CHECKOUT          = 'v69';
     const VERSION_CHECKOUT_UTILITY  = 'v1';
-    const VERSION_PAYMENT_PAYMENT   = 'v67';
+    const VERSION_PAYMENT_PAYMENT   = 'v69';
     const VERSION_PAYMENT_RECURRING = 'v25';
     const VERSION_PAYMENT_PAYOUT    = 'v30';
 
@@ -39,6 +39,9 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
     const SERVICE_GROUP_PAYMENT_PAYMENTMETHODS      = 'paymentMethods';
     const SERVICE_GROUP_PAYMENT_PAYMENTS            = 'payments';
     const SERVICE_GROUP_PAYMENT_PAYMENTS_DETAILS    = 'payments/details';
+    const SERVICE_GROUP_PAYMENT_SESSIONS            = 'sessions';
+    const SERVICE_GROUP_PAYMENT_MODIFICATIONS       = 'payments/{paymentPspReference}/{modificationAction}';
+
 
     const SERVICE_GROUP_RECURRING_LISTRECURRINGDETAILS      = 'listRecurringDetails';
     const SERVICE_GROUP_RECURRING_DISABLE                   = 'disable';

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -19,7 +19,6 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
 
     // Default values for live environment configuration
     const DEFAULT_PREFIX_LIVE = '';
-    const DEFAULT_INSTANCE_LIVE = 'live';
 
     const VERSION_DIRECTORY         = 'v2';
     const VERSION_CHECKOUT          = 'v69';
@@ -105,7 +104,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
      */
     protected function getLiveInstanceValue()
     {
-        return $this->getLiveInstance() ?: static::DEFAULT_INSTANCE_LIVE;
+        return $this->getLiveInstance() ?: static::INSTANCE_LIVE;
     }
 
     /**

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -4,11 +4,13 @@ namespace Omnipay\Adyen\Message;
 
 use Omnipay\Common\Message\AbstractRequest as OmnipayAbstractRequest;
 use Omnipay\Adyen\Traits\GatewayParameters;
+use Omnipay\Adyen\Traits\PreservedParameters;
 use Omnipay\Common\Exception\InvalidRequestException;
 
 abstract class AbstractRequest extends OmnipayAbstractRequest
 {
     use GatewayParameters;
+    use PreservedParameters;
 
     /**
      * Constants for URL construction.

--- a/src/Message/Api/AuthorizeRequest.php
+++ b/src/Message/Api/AuthorizeRequest.php
@@ -75,6 +75,9 @@ class AuthorizeRequest extends AbstractApiRequest
 
         $data = $this->addPaymentMethodData($data);
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Api/CancelRequest.php
+++ b/src/Message/Api/CancelRequest.php
@@ -38,6 +38,9 @@ class CancelRequest extends AbstractApiRequest
             $data['reference'] = $transactionId;
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Checkout/AuthorizeRequest.php
+++ b/src/Message/Checkout/AuthorizeRequest.php
@@ -66,9 +66,9 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         $data = [
             'additionalData' => $additionalData,
             'amount' => $amount,
-            'reference' => 'GISPENOUTLETNL-'.(string)$this->getTransactionId(),
+            'reference' => $this->getTransactionId(),
             'merchantAccount' => $this->getMerchantAccount(),
-            'shopperInteraction' => 'Ecommerce'
+            'shopperInteraction' => 'Ecommerce',
         ];
 
         if (!empty($this->getShopperReference())) {
@@ -85,6 +85,10 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         }
         if (!empty($this->getOrigin())) {
             $data['origin'] = $this->getOrigin();
+        }
+
+        if (!empty($this->getCaptureDelayHours())) {
+            $data['captureDelayHours'] = (int) $this->getCaptureDelayHours();
         }
 
         $data = $this->addPaymentMethodData($data);
@@ -164,4 +168,15 @@ class AuthorizeRequest extends AbstractCheckoutRequest
 
         return $data;
     }
+
+    public function setCaptureDelayHours($captureDelayHours)
+    {
+        $this->setParameter('captureDelayHours', $captureDelayHours);
+    }
+
+    public function getCaptureDelayHours()
+    {
+        return $this->getParameter('captureDelayHours');
+    }
+
 }

--- a/src/Message/Checkout/AuthorizeRequest.php
+++ b/src/Message/Checkout/AuthorizeRequest.php
@@ -71,33 +71,11 @@ class AuthorizeRequest extends AbstractCheckoutRequest
             'shopperInteraction' => 'Ecommerce',
         ];
 
-        if (!empty($this->getShopperReference())) {
-            $data['shopperReference'] = $this->getShopperReference();
-        }
-        if (!empty($this->getReturnUrl())) {
-            $data['returnUrl'] = $this->getReturnUrl();
-        }
-        if (!empty($this->getShopperName())) {
-            $data['shopperName'] = $this->getShopperName();
-        }
-        if (!empty($this->getShopperEmail())) {
-            $data['shopperEmail'] = $this->getShopperEmail();
-        }
-        if (!empty($this->getClientIp())) {
-            $data['shopperIP'] = $this->getClientIp();
-        }
-        if (!empty($this->getBillingAddress())) {
-            $data['billingAddress'] = $this->getBillingAddress();
-        }
-        if (!empty($this->getDeliveryAddress())) {
-            $data['deliveryAddress'] = $this->getDeliveryAddress();
-        }
-        if (!empty($this->getBrowserInfo())) {
-            $data['browserInfo'] = $this->getBrowserInfo();
-        }
         if (!empty($this->getOrigin())) {
             $data['origin'] = $this->getOrigin();
         }
+
+        $data = $this->addCommonOptionalParameters($data);
 
         if (!empty($this->getCaptureDelayHours())) {
             $data['captureDelayHours'] = (int) $this->getCaptureDelayHours();
@@ -106,8 +84,8 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         $data = $this->addPaymentMethodData($data);
 
         if (isset($data['paymentMethod']['storedPaymentMethodId'])) {
-            $data['recurringProcessingModel'] = $this->getProcessingModel() ?? 'CardOnFile';
-            $data['shopperInteraction'] = 'ContAuth';
+            $data['recurringProcessingModel'] = $this->getRecurringProcessingModel() ?? 'CardOnFile';
+            $data['shopperInteraction'] = $this->getShopperInteraction() ?? 'ContAuth';
         }
 
         return $data;

--- a/src/Message/Checkout/AuthorizeRequest.php
+++ b/src/Message/Checkout/AuthorizeRequest.php
@@ -77,8 +77,20 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         if (!empty($this->getReturnUrl())) {
             $data['returnUrl'] = $this->getReturnUrl();
         }
+        if (!empty($this->getShopperName())) {
+            $data['shopperName'] = $this->getShopperName();
+        }
+        if (!empty($this->getShopperEmail())) {
+            $data['shopperEmail'] = $this->getShopperEmail();
+        }
         if (!empty($this->getClientIp())) {
             $data['shopperIP'] = $this->getClientIp();
+        }
+        if (!empty($this->getBillingAddress())) {
+            $data['billingAddress'] = $this->getBillingAddress();
+        }
+        if (!empty($this->getDeliveryAddress())) {
+            $data['deliveryAddress'] = $this->getDeliveryAddress();
         }
         if (!empty($this->getBrowserInfo())) {
             $data['browserInfo'] = $this->getBrowserInfo();
@@ -94,7 +106,7 @@ class AuthorizeRequest extends AbstractCheckoutRequest
         $data = $this->addPaymentMethodData($data);
 
         if (isset($data['paymentMethod']['storedPaymentMethodId'])) {
-            $data['recurringProcessingModel'] = 'CardOnFile';
+            $data['recurringProcessingModel'] = $this->getProcessingModel() ?? 'CardOnFile';
             $data['shopperInteraction'] = 'ContAuth';
         }
 

--- a/src/Message/Checkout/CompleteAuthorizeRequest.php
+++ b/src/Message/Checkout/CompleteAuthorizeRequest.php
@@ -36,6 +36,9 @@ class CompleteAuthorizeRequest extends AbstractCheckoutRequest
 
         //$data = $this->addDetailsData($data);
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Checkout/CompleteAuthorizeResponse.php
+++ b/src/Message/Checkout/CompleteAuthorizeResponse.php
@@ -40,4 +40,9 @@ class CompleteAuthorizeResponse extends AbstractResponse
     {
         return $this->getDataItem('pspReference');
     }
+
+    public function getCode()
+    {
+        return $this->getResultCode();
+    }
 }

--- a/src/Message/Checkout/CreateCardRequest.php
+++ b/src/Message/Checkout/CreateCardRequest.php
@@ -41,8 +41,12 @@ class CreateCardRequest extends AbstractCheckoutRequest
             'reference' => $this->getTransactionId(),
             'shopperInteraction' => 'Ecommerce',
             'recurringProcessingModel' => 'CardOnFile',
-            "shopperReference" => $this->getShopperReference(),
+            'shopperReference' => $this->getShopperReference(),
         ];
+
+        if (!empty($this->getRequestedTestAcquirerResponseCode())) {
+            $data['additionalData']['RequestedTestAcquirerResponseCode'] = $this->getRequestedTestAcquirerResponseCode();
+        }
 
         return $data;
     }
@@ -55,5 +59,15 @@ class CreateCardRequest extends AbstractCheckoutRequest
     public function setPaymentMethod($paymentMethod)
     {
         $this->setParameter('paymentMethod', $paymentMethod);
+    }
+
+    public function setRequestedTestAcquirerResponseCode($requestedTestAcquirerResponseCode)
+    {
+        $this->setParameter('requestedTestAcquirerResponseCode', $requestedTestAcquirerResponseCode);
+    }
+
+    public function getRequestedTestAcquirerResponseCode()
+    {
+        return $this->getParameter('requestedTestAcquirerResponseCode');
     }
 }

--- a/src/Message/Checkout/CreateCardRequest.php
+++ b/src/Message/Checkout/CreateCardRequest.php
@@ -44,6 +44,7 @@ class CreateCardRequest extends AbstractCheckoutRequest
             'shopperReference' => $this->getShopperReference(),
         ];
 
+        $data = $this->addCommonOptionalParameters($data);
         if (!empty($this->getRequestedTestAcquirerResponseCode())) {
             $data['additionalData']['RequestedTestAcquirerResponseCode'] = $this->getRequestedTestAcquirerResponseCode();
         }

--- a/src/Message/Checkout/CreateCardRequest.php
+++ b/src/Message/Checkout/CreateCardRequest.php
@@ -39,8 +39,8 @@ class CreateCardRequest extends AbstractCheckoutRequest
             "storePaymentMethod" => true,
             'merchantAccount' => $this->getMerchantAccount(),
             'reference' => $this->getTransactionId(),
-            'shopperInteraction' => 'Ecommerce',
-            'recurringProcessingModel' => 'CardOnFile',
+            'shopperInteraction' => $this->getShopperInteraction() ?? 'Ecommerce',
+            'recurringProcessingModel' => $this->getRecurringProcessingModel() ?? 'CardOnFile',
             'shopperReference' => $this->getShopperReference(),
         ];
 

--- a/src/Message/Checkout/CreateCardResponse.php
+++ b/src/Message/Checkout/CreateCardResponse.php
@@ -14,8 +14,19 @@ class CreateCardResponse extends AbstractResponse
         return (isset($this->data['resultCode']) && $this->data['resultCode'] == 'Authorised');
     }
 
+    /**
+     * @return string|null
+     */
     public function getToken()
     {
-        return $this->data['additionalData']['recurring.recurringDetailReference'];
+        return $this->data['additionalData']['recurring.recurringDetailReference'] ?? null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMessage()
+    {
+        return $this->getDataItem('refusalReason');
     }
 }

--- a/src/Message/Checkout/CreateCardResponse.php
+++ b/src/Message/Checkout/CreateCardResponse.php
@@ -29,4 +29,9 @@ class CreateCardResponse extends AbstractResponse
     {
         return $this->getDataItem('refusalReason');
     }
+
+    public function getCode()
+    {
+        return $this->data['resultCode'] ?? null;
+    }
 }

--- a/src/Message/Checkout/CreateModificationRequest.php
+++ b/src/Message/Checkout/CreateModificationRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Omnipay\Adyen\Message\Checkout;
+
+use Omnipay\Adyen\Message\AbstractCheckoutRequest;
+use Omnipay\Adyen\Message\AbstractRequest;
+
+class CreateModificationRequest extends AbstractCheckoutRequest
+{
+
+    public function createResponse($data)
+    {
+        return new CreateModificationResponse($this, $data);
+    }
+
+    public function getEndpoint($parameters = null)
+    {
+        $endpoint = $this->getCheckoutUrl(
+            AbstractRequest::SERVICE_GROUP_PAYMENT_MODIFICATIONS
+        );
+
+        foreach ($parameters as $name => $value) {
+            if (gettype($value) === 'string') {
+                $endpoint = str_replace('{'.$name.'}', $value, $endpoint);
+            }
+        }
+
+        return $endpoint;
+    }
+
+    public function getData()
+    {
+        $this->validate(
+            'merchantAccount',
+            'amount',
+            'currency',
+            'transactionId',
+            'modificationAction'
+        );
+
+        $data = [
+            'amount' => [
+                'value' => $this->getAmountInteger(),
+                'currency' => $this->getCurrency(),
+            ],
+            'merchantAccount' => $this->getMerchantAccount(),
+            'reference' => $this->getTransactionId(),
+            'paymentPspReference' => $this->getTransactionReference(),
+            'modificationAction' => $this->getModificationAction(),
+        ];
+
+        return $data;
+    }
+    public function setModificationAction($modificationAction)
+    {
+        $this->setParameter('modificationAction', $modificationAction);
+    }
+    public function getModificationAction()
+    {
+        return $this->getParameter('modificationAction');
+    }
+
+}

--- a/src/Message/Checkout/CreateModificationRequest.php
+++ b/src/Message/Checkout/CreateModificationRequest.php
@@ -49,6 +49,9 @@ class CreateModificationRequest extends AbstractCheckoutRequest
             'modificationAction' => $this->getModificationAction(),
         ];
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
     public function setModificationAction($modificationAction)

--- a/src/Message/Checkout/CreateModificationResponse.php
+++ b/src/Message/Checkout/CreateModificationResponse.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Omnipay\Adyen\Message\Checkout;
+
+use Omnipay\Adyen\Traits\DataWalker;
+use Omnipay\Common\Message\AbstractResponse;
+
+class CreateModificationResponse extends AbstractResponse
+{
+    use DataWalker;
+
+    protected $payload;
+
+    public function isSuccessful()
+    {
+        return (isset($this->data['status']) && $this->data['status'] == 'received');
+    }
+
+    public function getData()
+    {
+        if ($this->payload === null) {
+            $this->payload = parent::getData();
+
+            if (is_array($this->payload)) {
+                $this->payload = $this->expandKeys($this->payload);
+            }
+
+        }
+
+        return $this->payload;
+    }
+
+
+}

--- a/src/Message/Checkout/CreateModificationResponse.php
+++ b/src/Message/Checkout/CreateModificationResponse.php
@@ -30,5 +30,10 @@ class CreateModificationResponse extends AbstractResponse
         return $this->payload;
     }
 
+    public function getTransactionReference()
+    {
+        return $this->getDataItem('paymentPspReference');
+    }
+
 
 }

--- a/src/Message/Checkout/CreateModificationResponse.php
+++ b/src/Message/Checkout/CreateModificationResponse.php
@@ -35,5 +35,9 @@ class CreateModificationResponse extends AbstractResponse
         return $this->getDataItem('paymentPspReference');
     }
 
+    public function getCode()
+    {
+        return $this->data['status'] ?? null;
+    }
 
 }

--- a/src/Message/Checkout/CreateSessionRequest.php
+++ b/src/Message/Checkout/CreateSessionRequest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Omnipay\Adyen\Message\Checkout;
+
+use Omnipay\Adyen\Message\AbstractCheckoutRequest;
+use Omnipay\Adyen\Message\AbstractRequest;
+
+class CreateSessionRequest extends AbstractCheckoutRequest
+{
+
+    public function createResponse($data)
+    {
+        return new CreateSessionResponse($this, $data);
+    }
+
+    public function getEndpoint()
+    {
+        return $this->getCheckoutUrl(
+            AbstractRequest::SERVICE_GROUP_PAYMENT_SESSIONS
+        );
+    }
+
+    public function getData()
+    {
+        $this->validate(
+            'merchantAccount',
+            'currency',
+            'transactionId',
+            'returnUrl',
+            'countryCode'
+        );
+
+        $data = [
+            'amount' => [
+                'value' => 0,
+                'currency' => $this->getCurrency(),
+            ],
+            'merchantAccount' => $this->getMerchantAccount(),
+            'reference' => $this->getTransactionId(),
+            'returnUrl' => $this->getReturnUrl(),
+            'countryCode' => $this->getCountryCode(),
+        ];
+
+        if (!empty($this->getStorePaymentMethod())) {
+            $data['storePaymentMethod'] = $this->getStorePaymentMethod();
+        }
+
+        if (!empty($this->getShopperInteraction())) {
+            $data['shopperInteraction'] = $this->getShopperInteraction();
+        }
+
+        if (!empty($this->getRecurringProcessingModel())) {
+            $data['recurringProcessingModel'] = $this->getRecurringProcessingModel();
+        }
+
+        if (!empty($this->getShopperReference())) {
+            $data['shopperReference'] = $this->getShopperReference();
+        }
+
+        return $data;
+    }
+
+    public function setStorePaymentMethod($storePaymentMethod)
+    {
+        $this->setParameter('storePaymentMethod', $storePaymentMethod);
+    }
+    public function getStorePaymentMethod()
+    {
+        return $this->getParameter('storePaymentMethod');
+    }
+
+    public function setShopperInteraction($shopperInteraction)
+    {
+        $this->setParameter('shopperInteraction', $shopperInteraction);
+    }
+    public function getShopperInteraction()
+    {
+        return $this->getParameter('shopperInteraction');
+    }
+
+    public function setRecurringProcessingModel($recurringProcessingModel)
+    {
+        $this->setParameter('recurringProcessingModel', $recurringProcessingModel);
+    }
+    public function getRecurringProcessingModel()
+    {
+        return $this->getParameter('recurringProcessingModel');
+    }
+}

--- a/src/Message/Checkout/CreateSessionRequest.php
+++ b/src/Message/Checkout/CreateSessionRequest.php
@@ -68,22 +68,4 @@ class CreateSessionRequest extends AbstractCheckoutRequest
     {
         return $this->getParameter('storePaymentMethod');
     }
-
-    public function setShopperInteraction($shopperInteraction)
-    {
-        $this->setParameter('shopperInteraction', $shopperInteraction);
-    }
-    public function getShopperInteraction()
-    {
-        return $this->getParameter('shopperInteraction');
-    }
-
-    public function setRecurringProcessingModel($recurringProcessingModel)
-    {
-        $this->setParameter('recurringProcessingModel', $recurringProcessingModel);
-    }
-    public function getRecurringProcessingModel()
-    {
-        return $this->getParameter('recurringProcessingModel');
-    }
 }

--- a/src/Message/Checkout/CreateSessionRequest.php
+++ b/src/Message/Checkout/CreateSessionRequest.php
@@ -57,6 +57,9 @@ class CreateSessionRequest extends AbstractCheckoutRequest
             $data['shopperReference'] = $this->getShopperReference();
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 

--- a/src/Message/Checkout/CreateSessionResponse.php
+++ b/src/Message/Checkout/CreateSessionResponse.php
@@ -11,7 +11,9 @@ class CreateSessionResponse extends AbstractResponse
 
     public function isSuccessful()
     {
-        return count($this->getData()) > 0;
+        return !$this->getMessage()
+            && $this->getSessionId() !== null
+            && $this->getSessionData() !== null;
     }
 
     public function getSessionId()
@@ -36,6 +38,13 @@ class CreateSessionResponse extends AbstractResponse
             'sessionData' => $this->getSessionData(),
             'expiresAt' => $this->getExpiresAt(),
         ];
+    }
+
+    public function getMessage()
+    {
+        return isset($this->getData()['message'])
+            ? $this->getData()['message']
+            : null;
     }
 
 }

--- a/src/Message/Checkout/CreateSessionResponse.php
+++ b/src/Message/Checkout/CreateSessionResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Omnipay\Adyen\Message\Checkout;
+
+use Omnipay\Adyen\Traits\DataWalker;
+use Omnipay\Common\Message\AbstractResponse;
+
+class CreateSessionResponse extends AbstractResponse
+{
+    use DataWalker;
+
+    public function isSuccessful()
+    {
+        return count($this->getData()) > 0;
+    }
+
+    public function getSessionId()
+    {
+        return $this->getDataItem('id');
+    }
+
+    public function getSessionData()
+    {
+        return $this->getDataItem('sessionData');
+    }
+
+    public function getExpiresAt()
+    {
+        return $this->getDataItem('expiresAt');
+    }
+
+    public function getSession()
+    {
+        return [
+            'id' => $this->getSessionId(),
+            'sessionData' => $this->getSessionData(),
+            'expiresAt' => $this->getExpiresAt(),
+        ];
+    }
+
+}

--- a/src/Message/Checkout/PaymentMethodRequest.php
+++ b/src/Message/Checkout/PaymentMethodRequest.php
@@ -48,6 +48,9 @@ class PaymentMethodRequest extends AbstractCheckoutRequest
             $data['shopperReference'] = $this->getShopperReference();
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        $data = $this->mergePreservedParameters($data);
+
         return $data;
     }
 }

--- a/src/Message/Checkout/PaymentMethodResponse.php
+++ b/src/Message/Checkout/PaymentMethodResponse.php
@@ -11,11 +11,19 @@ class PaymentMethodResponse extends AbstractResponse
 
     public function isSuccessful()
     {
-        return count($this->getData()) > 0;
+        return !$this->getMessage()
+            && count($this->getData()) > 0;
     }
 
     public function getPaymentMethodsResponse()
     {
         return json_encode($this->data);
+    }
+
+    public function getMessage()
+    {
+        return isset($this->getData()['message'])
+            ? $this->getData()['message']
+            : null;
     }
 }

--- a/src/Message/Hpp/AuthorizeRequest.php
+++ b/src/Message/Hpp/AuthorizeRequest.php
@@ -100,6 +100,10 @@ class AuthorizeRequest extends AbstractHppRequest
             }
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        // (must be done before signature generation)
+        $data = $this->mergePreservedParameters($data);
+
         // Finally add the HMAC signature for the data.
 
         $signingString = $this->getSigningString($data);

--- a/src/Message/Hpp/FetchPaymentMethodsRequest.php
+++ b/src/Message/Hpp/FetchPaymentMethodsRequest.php
@@ -46,6 +46,10 @@ class FetchPaymentMethodsRequest extends AbstractHppRequest
             $data['blockedMethods'] = $this->getBlockedMethods();
         }
 
+        // Merge in any preserved parameters that have been explicitly allowed
+        // (must be done before signature generation)
+        $data = $this->mergePreservedParameters($data);
+
         // Finally add the HMAC signature for the data.
 
         $signingString = $this->getSigningString($data);

--- a/src/Traits/GatewayParameters.php
+++ b/src/Traits/GatewayParameters.php
@@ -263,4 +263,56 @@ trait GatewayParameters
     {
         return $this->getParameter('origin');
     }
+
+    public function getMerchantAccountId()
+    {
+        return $this->getParameter('merchantAccountId');
+    }
+
+    public function setMerchantAccountId($value)
+    {
+        return $this->setParameter('merchantAccountId', $value);
+    }
+
+    /**
+     * Get the live environment prefix.
+     *
+     * @return string
+     */
+    public function getLivePrefix()
+    {
+        return $this->getParameter('livePrefix');
+    }
+
+    /**
+     * Set the live environment prefix.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setLivePrefix($value)
+    {
+        return $this->setParameter('livePrefix', $value);
+    }
+
+    /**
+     * Get the live environment instance.
+     *
+     * @return string
+     */
+    public function getLiveInstance()
+    {
+        return $this->getParameter('liveInstance');
+    }
+
+    /**
+     * Set the live environment instance.
+     *
+     * @param string $value
+     * @return $this
+     */
+    public function setLiveInstance($value)
+    {
+        return $this->setParameter('liveInstance', $value);
+    }
 }

--- a/src/Traits/GatewayParameters.php
+++ b/src/Traits/GatewayParameters.php
@@ -356,13 +356,31 @@ trait GatewayParameters
         return $this->getParameter('deliveryAddress');
     }
 
-    public function setProcessingModel(string $value)
+    public function setShopperInteraction($shopperInteraction)
     {
-        return $this->setParameter('processingModel', $value);
+        $this->setParameter('shopperInteraction', $shopperInteraction);
+    }
+    public function getShopperInteraction()
+    {
+        return $this->getParameter('shopperInteraction');
     }
 
-    public function getProcessingModel()
+    public function setRecurringProcessingModel($recurringProcessingModel)
     {
-        return $this->getParameter('processingModel');
+        $this->setParameter('recurringProcessingModel', $recurringProcessingModel);
+    }
+    public function getRecurringProcessingModel()
+    {
+        return $this->getParameter('recurringProcessingModel');
+    }
+
+    public function setRiskData($riskData)
+    {
+        $this->setParameter('riskData', $riskData);
+    }
+
+    public function getRiskData()
+    {
+        return $this->getParameter('riskData');
     }
 }

--- a/src/Traits/GatewayParameters.php
+++ b/src/Traits/GatewayParameters.php
@@ -234,6 +234,26 @@ trait GatewayParameters
         return $this->setParameter('channel', $value);
     }
 
+    public function setShopperName($shopperName)
+    {
+        $this->setParameter('shopperName', $shopperName);
+    }
+
+    public function getShopperName()
+    {
+        return $this->getParameter('shopperName');
+    }
+
+    public function setShopperEmail($shopperEmail)
+    {
+        $this->setParameter('shopperEmail', $shopperEmail);
+    }
+
+    public function getShopperEmail()
+    {
+        return $this->getParameter('shopperEmail');
+    }
+
     public function setShopperReference($shopperReference)
     {
         $this->setParameter('shopperReference', $shopperReference);
@@ -314,5 +334,35 @@ trait GatewayParameters
     public function setLiveInstance($value)
     {
         return $this->setParameter('liveInstance', $value);
+    }
+
+    public function setBillingAddress(?array $value)
+    {
+        return $this->setParameter('billingAddress', $value);
+    }
+
+    public function getBillingAddress()
+    {
+        return $this->getParameter('billingAddress');
+    }
+
+    public function setDeliveryAddress(?array $value)
+    {
+        return $this->setParameter('deliveryAddress', $value);
+    }
+
+    public function getDeliveryAddress()
+    {
+        return $this->getParameter('deliveryAddress');
+    }
+
+    public function setProcessingModel(string $value)
+    {
+        return $this->setParameter('processingModel', $value);
+    }
+
+    public function getProcessingModel()
+    {
+        return $this->getParameter('processingModel');
     }
 }

--- a/src/Traits/PreservedParameters.php
+++ b/src/Traits/PreservedParameters.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Omnipay\Adyen\Traits;
+
+/**
+ * Trait for handling additional parameters that should be preserved and passed through to the API.
+ *
+ * This allows userland code to pass extra parameters through to Adyen without requiring
+ * modifications to the package for each new parameter.
+ *
+ * Usage:
+ *   // First, declare which parameters should be preserved
+ *   $gateway->setPreservedParameterKeys(['lineItems', 'metadata', 'applicationInfo']);
+ *
+ *   // Then, when making requests, those parameters will be included if set
+ *   $gateway->session([
+ *       'amount' => '10.00',
+ *       'lineItems' => [...],  // This will be preserved
+ *       'metadata' => [...],   // This will be preserved
+ *   ]);
+ */
+trait PreservedParameters
+{
+    /**
+     * Get the list of parameter keys that should be preserved.
+     *
+     * @return array
+     */
+    public function getPreservedParameterKeys(): array
+    {
+        return $this->getParameter('preservedParameterKeys') ?? [];
+    }
+
+    /**
+     * Set the list of parameter keys that should be preserved.
+     *
+     * @param array $keys Array of parameter names to preserve
+     * @return $this
+     */
+    public function setPreservedParameterKeys(array $keys)
+    {
+        return $this->setParameter('preservedParameterKeys', $keys);
+    }
+
+    /**
+     * Add a single parameter key to the preserved list.
+     *
+     * @param string $key The parameter name to preserve
+     * @return $this
+     */
+    public function addPreservedParameterKey(string $key)
+    {
+        $keys = $this->getPreservedParameterKeys();
+
+        if (!in_array($key, $keys, true)) {
+            $keys[] = $key;
+        }
+
+        return $this->setPreservedParameterKeys($keys);
+    }
+
+    /**
+     * Remove a parameter key from the preserved list.
+     *
+     * @param string $key The parameter name to remove
+     * @return $this
+     */
+    public function removePreservedParameterKey(string $key)
+    {
+        $keys = $this->getPreservedParameterKeys();
+        $keys = array_filter($keys, fn($k) => $k !== $key);
+
+        return $this->setPreservedParameterKeys(array_values($keys));
+    }
+
+    /**
+     * Get the data for all preserved parameters that have values.
+     *
+     * This method iterates through the preserved parameter keys and returns
+     * an associative array of key => value for all parameters that have been set.
+     *
+     * @return array
+     */
+    public function getPreservedParametersData(): array
+    {
+        $data = [];
+
+        foreach ($this->getPreservedParameterKeys() as $key) {
+            $value = $this->getParameter($key);
+
+            if ($value !== null) {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * Merge preserved parameters into an existing data array.
+     *
+     * This is a convenience method for use in getData() implementations.
+     * Preserved parameters will NOT override existing keys in the data array.
+     *
+     * @param array $data The existing data array
+     * @return array The merged data array
+     */
+    public function mergePreservedParameters(array $data): array
+    {
+        $preserved = $this->getPreservedParametersData();
+
+        // Only add preserved parameters that don't already exist in data
+        foreach ($preserved as $key => $value) {
+            if (!array_key_exists($key, $data)) {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Omnipay\Adyen\Tests\Message;
+
+use Omnipay\Adyen\Message\AbstractRequest;
+use PHPUnit\Framework\TestCase;
+use Omnipay\Common\Http\ClientInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+
+class TestRequest extends AbstractRequest
+{
+    public function getData() { return []; }
+    public function sendData($data) { return null; }
+}
+
+class AbstractRequestTest extends TestCase
+{
+    protected $request;
+
+    protected function setUp(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpRequest = $this->createMock(HttpRequest::class);
+        $this->request = new TestRequest($httpClient, $httpRequest);
+    }
+
+    public function testGetCheckoutUrlTestMode()
+    {
+        $this->request->setTestMode(true);
+        
+        $url = $this->request->getCheckoutUrl('payments');
+        
+        $this->assertEquals(
+            'https://checkout-test.adyen.com/v69/payments',
+            $url
+        );
+    }
+
+    public function testGetCheckoutUrlLiveMode()
+    {
+        $this->request->setTestMode(false);
+        
+        // Test with default values
+        $url = $this->request->getCheckoutUrl('payments');
+        
+        $this->assertEquals(
+            'https://checkout-live.adyenpayments.com/checkout/v69/payments',
+            $url
+        );
+
+        // Test with custom prefix and instance
+        $this->request->setLivePrefix('xxx-xxx');
+        $this->request->setLiveInstance('custom');
+        
+        $url = $this->request->getCheckoutUrl('payments');
+        
+        $this->assertEquals(
+            'https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/v69/payments',
+            $url
+        );
+    }
+
+    public function testGetCheckoutUtilityUrlTestMode()
+    {
+        $this->request->setTestMode(true);
+        
+        $url = $this->request->getCheckoutUtilityUrl();
+        
+        $this->assertEquals(
+            'https://checkout-test.adyen.com/v1',
+            $url
+        );
+    }
+
+    public function testGetCheckoutUtilityUrlLiveMode()
+    {
+        $this->request->setTestMode(false);
+        
+        // Test with default values
+        $url = $this->request->getCheckoutUtilityUrl();
+        
+        $this->assertEquals(
+            'https://checkout-live.adyenpayments.com/checkout/v1',
+            $url
+        );
+
+        // Test with custom prefix and instance
+        $this->request->setLivePrefix('xxx-xxx');
+        $this->request->setLiveInstance('custom');
+        
+        $url = $this->request->getCheckoutUtilityUrl();
+        
+        $this->assertEquals(
+            'https://xxx-xxx-checkout-custom.adyenpayments.com/checkout/v1',
+            $url
+        );
+    }
+} 

--- a/tests/Traits/PreservedParametersTest.php
+++ b/tests/Traits/PreservedParametersTest.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace Omnipay\Adyen\Tests\Traits;
+
+use Omnipay\Adyen\Message\AbstractRequest;
+use PHPUnit\Framework\TestCase;
+use Omnipay\Common\Http\ClientInterface;
+use Symfony\Component\HttpFoundation\Request as HttpRequest;
+
+/**
+ * Concrete implementation of AbstractRequest for testing
+ */
+class TestableRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $data = [
+            'merchantAccount' => $this->getMerchantAccount(),
+            'amount' => $this->getAmountInteger(),
+        ];
+
+        // Merge preserved parameters like the real request classes do
+        $data = $this->mergePreservedParameters($data);
+
+        return $data;
+    }
+
+    public function sendData($data)
+    {
+        return null;
+    }
+}
+
+class PreservedParametersTest extends TestCase
+{
+    protected TestableRequest $request;
+
+    protected function setUp(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpRequest = $this->createMock(HttpRequest::class);
+        $this->request = new TestableRequest($httpClient, $httpRequest);
+    }
+
+    public function test_setPreservedParameterKeys_stores_keys()
+    {
+        $keys = ['lineItems', 'metadata', 'applicationInfo'];
+
+        $result = $this->request->setPreservedParameterKeys($keys);
+
+        $this->assertSame($this->request, $result); // Should return $this for chaining
+        $this->assertEquals($keys, $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_getPreservedParameterKeys_returns_empty_array_by_default()
+    {
+        $this->assertEquals([], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_addPreservedParameterKey_adds_single_key()
+    {
+        $this->request->addPreservedParameterKey('lineItems');
+        $this->request->addPreservedParameterKey('metadata');
+
+        $this->assertEquals(['lineItems', 'metadata'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_addPreservedParameterKey_does_not_duplicate_keys()
+    {
+        $this->request->addPreservedParameterKey('lineItems');
+        $this->request->addPreservedParameterKey('lineItems');
+        $this->request->addPreservedParameterKey('metadata');
+        $this->request->addPreservedParameterKey('lineItems');
+
+        $this->assertEquals(['lineItems', 'metadata'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_removePreservedParameterKey_removes_key()
+    {
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata', 'applicationInfo']);
+
+        $result = $this->request->removePreservedParameterKey('metadata');
+
+        $this->assertSame($this->request, $result); // Should return $this for chaining
+        $this->assertEquals(['lineItems', 'applicationInfo'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_removePreservedParameterKey_handles_nonexistent_key()
+    {
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata']);
+
+        $this->request->removePreservedParameterKey('nonexistent');
+
+        $this->assertEquals(['lineItems', 'metadata'], $this->request->getPreservedParameterKeys());
+    }
+
+    public function test_getPreservedParametersData_returns_set_parameters()
+    {
+        $lineItems = [
+            ['description' => 'Product 1', 'quantity' => 1],
+            ['description' => 'Product 2', 'quantity' => 2],
+        ];
+        $metadata = ['orderId' => '12345'];
+
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata', 'applicationInfo']);
+        $this->request->setParameter('lineItems', $lineItems);
+        $this->request->setParameter('metadata', $metadata);
+        // applicationInfo is not set, so it should be excluded
+
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals([
+            'lineItems' => $lineItems,
+            'metadata' => $metadata,
+        ], $data);
+    }
+
+    public function test_getPreservedParametersData_excludes_null_values()
+    {
+        $this->request->setPreservedParameterKeys(['lineItems', 'metadata']);
+        $this->request->setParameter('lineItems', null);
+        $this->request->setParameter('metadata', ['key' => 'value']);
+
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals([
+            'metadata' => ['key' => 'value'],
+        ], $data);
+    }
+
+    public function test_mergePreservedParameters_adds_to_data_array()
+    {
+        $lineItems = [['description' => 'Product 1']];
+
+        $this->request->setPreservedParameterKeys(['lineItems']);
+        $this->request->setParameter('lineItems', $lineItems);
+
+        $existingData = ['merchantAccount' => 'TestMerchant', 'amount' => 1000];
+
+        $result = $this->request->mergePreservedParameters($existingData);
+
+        $this->assertEquals([
+            'merchantAccount' => 'TestMerchant',
+            'amount' => 1000,
+            'lineItems' => $lineItems,
+        ], $result);
+    }
+
+    public function test_mergePreservedParameters_does_not_override_existing_keys()
+    {
+        $this->request->setPreservedParameterKeys(['amount', 'lineItems']);
+        $this->request->setParameter('amount', 9999); // Try to override
+        $this->request->setParameter('lineItems', [['item' => 1]]);
+
+        $existingData = ['merchantAccount' => 'TestMerchant', 'amount' => 1000];
+
+        $result = $this->request->mergePreservedParameters($existingData);
+
+        // amount should NOT be overridden
+        $this->assertEquals(1000, $result['amount']);
+        // lineItems should be added
+        $this->assertEquals([['item' => 1]], $result['lineItems']);
+    }
+
+    public function test_getData_includes_preserved_parameters()
+    {
+        $lineItems = [['description' => 'Test Product', 'quantity' => 1]];
+
+        $this->request->setMerchantAccount('TestMerchant');
+        $this->request->setAmount('10.00');
+        $this->request->setPreservedParameterKeys(['lineItems']);
+        $this->request->setParameter('lineItems', $lineItems);
+
+        $data = $this->request->getData();
+
+        $this->assertEquals('TestMerchant', $data['merchantAccount']);
+        $this->assertEquals(1000, $data['amount']);
+        $this->assertEquals($lineItems, $data['lineItems']);
+    }
+
+    public function test_preserved_parameters_support_nested_arrays()
+    {
+        $complexData = [
+            'level1' => [
+                'level2' => [
+                    'level3' => 'value',
+                    'items' => [1, 2, 3],
+                ],
+            ],
+        ];
+
+        $this->request->setPreservedParameterKeys(['complexData']);
+        $this->request->setParameter('complexData', $complexData);
+
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals(['complexData' => $complexData], $data);
+    }
+
+    public function test_preserved_parameters_empty_when_no_keys_set()
+    {
+        $this->request->setParameter('lineItems', [['item' => 1]]);
+        $this->request->setParameter('metadata', ['key' => 'value']);
+
+        // No preserved parameter keys set
+        $data = $this->request->getPreservedParametersData();
+
+        $this->assertEquals([], $data);
+    }
+}
+


### PR DESCRIPTION
We keep running into issues where we need to pass additional parameters through to Adyen, and we have to update this package to accomplish it. While I appreciate its whitelist approach, this has proven restrictive.

This PR allows us to define parameters we want to allow through first (sticking with the "whitelist" approach), and then pass those arbitrary parameters through in the various requests.